### PR TITLE
RHDHPAI-160: merge ai-lab-helm-chart pipeline/task with rhdh-pipeline

### DIFF
--- a/pac/pipelines/docker-build-ai-rhdh-pull-request.yaml
+++ b/pac/pipelines/docker-build-ai-rhdh-pull-request.yaml
@@ -1,0 +1,136 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  labels:
+    pipelines.openshift.io/runtime: generic
+    pipelines.openshift.io/strategy: docker
+    pipelines.openshift.io/used-by: build-cloud
+  name: docker-build-ai-rhdh-pull-request
+spec:
+  finally:
+    - name: show-sbom
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-container.results.IMAGE_URL)
+      taskRef:
+        name: show-sbom-rhdh
+    - name: show-summary
+      params:
+        - name: pipelinerun-name
+          value: $(context.pipelineRun.name)
+        - name: git-url
+          value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+        - name: image-url
+          value: $(params.output-image)
+        - name: build-task-status
+          value: $(tasks.build-container.status)
+      taskRef:
+        name: summary
+      workspaces:
+        - name: workspace
+          workspace: workspace
+  params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Force rebuild image
+      name: rebuild
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+  results:
+    - name: IMAGE_URL
+      value: $(tasks.build-container.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
+    - name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+  tasks:
+    - name: init
+      params:
+        - name: image-url
+          value: $(params.output-image)
+        - name: rebuild
+          value: $(params.rebuild)
+      taskRef:
+        name: init
+    - name: clone-repository
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.revision)
+      runAfter:
+        - init
+      taskRef:
+        name: git-clone
+      when:
+        - input: $(tasks.init.results.build)
+          operator: in
+          values:
+            - "true"
+      workspaces:
+        - name: output
+          workspace: workspace
+        - name: basic-auth
+          workspace: git-auth
+    - name: build-container
+      params:
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+        - name: CONTEXT
+          value: $(params.path-context)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.image-expires-after)
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: BUILD_ARGS
+          value:
+            - $(params.build-args[*])
+        - name: BUILD_ARGS_FILE
+          value: $(params.build-args-file)
+      runAfter:
+        - clone-repository
+      taskRef:
+        name: buildah-ai-rhdh
+      when:
+        - input: $(tasks.init.results.build)
+          operator: in
+          values:
+            - "true"
+      workspaces:
+        - name: source
+          workspace: workspace
+  workspaces:
+    - name: workspace
+    - name: git-auth
+      optional: true

--- a/pac/pipelines/docker-build-ai-rhdh-push-gitops.yaml
+++ b/pac/pipelines/docker-build-ai-rhdh-push-gitops.yaml
@@ -1,0 +1,159 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  labels:
+    pipelines.openshift.io/runtime: generic
+    pipelines.openshift.io/strategy: docker
+    pipelines.openshift.io/used-by: build-cloud
+  name: docker-build-ai-rhdh-push-gitops
+spec:
+  finally:
+    - name: show-sbom
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-container.results.IMAGE_URL)
+      taskRef:
+        name: show-sbom-rhdh
+    - name: show-summary
+      params:
+        - name: pipelinerun-name
+          value: $(context.pipelineRun.name)
+        - name: git-url
+          value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+        - name: image-url
+          value: $(params.output-image)
+        - name: build-task-status
+          value: $(tasks.build-container.status)
+      taskRef:
+        name: summary
+      workspaces:
+        - name: workspace
+          workspace: workspace
+  params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Force rebuild image
+      name: rebuild
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+    - default: gitops-auth-secret
+      description: 'Secret name to enable this pipeline to update the gitops repo with the new image. '
+      name: gitops-auth-secret-name
+      type: string
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+  results:
+    - name: IMAGE_URL
+      value: $(tasks.build-container.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
+    - name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+  tasks:
+    - name: init
+      params:
+        - name: image-url
+          value: $(params.output-image)
+        - name: rebuild
+          value: $(params.rebuild)
+      taskRef:
+        name: init
+    - name: clone-repository
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.revision)
+      runAfter:
+        - init
+      taskRef:
+        name: git-clone
+      when:
+        - input: $(tasks.init.results.build)
+          operator: in
+          values:
+            - "true"
+      workspaces:
+        - name: output
+          workspace: workspace
+        - name: basic-auth
+          workspace: git-auth
+    - name: build-container
+      params:
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+        - name: CONTEXT
+          value: $(params.path-context)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.image-expires-after)
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: BUILD_ARGS
+          value:
+            - $(params.build-args[*])
+        - name: BUILD_ARGS_FILE
+          value: $(params.build-args-file)
+      runAfter:
+        - clone-repository
+      taskRef:
+        name: buildah-ai-rhdh
+      when:
+        - input: $(tasks.init.results.build)
+          operator: in
+          values:
+            - "true"
+      workspaces:
+        - name: source
+          workspace: workspace
+    - name: update-deployment-gitops
+      params:
+        - name: gitops-repo-url
+          value: $(params.git-url)-gitops
+        - name: image
+          value: $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+        - name: gitops-auth-secret-name
+          value: $(params.gitops-auth-secret-name)
+      runAfter:
+        - build-container
+      taskRef:
+        kind: Task
+        name: update-deployment-gitops
+      workspaces:
+        - name: gitops-auth
+          optional: true
+          workspace: gitops-auth
+  workspaces:
+    - name: workspace
+    - name: git-auth
+      optional: true
+    - name: gitops-auth
+      optional: true

--- a/pac/pipelines/docker-build-ai-rhdh-push-patch.yaml
+++ b/pac/pipelines/docker-build-ai-rhdh-push-patch.yaml
@@ -5,7 +5,7 @@ metadata:
     pipelines.openshift.io/runtime: generic
     pipelines.openshift.io/strategy: docker
     pipelines.openshift.io/used-by: build-cloud
-  name: docker-build-ai-rhdh
+  name: docker-build-ai-rhdh-push-patch
 spec:
   finally:
     - name: show-sbom
@@ -59,10 +59,6 @@ spec:
       description: 'Secret name to enable this pipeline to update the gitops repo with the new image. '
       name: gitops-auth-secret-name
       type: string
-    - default: push
-      description: Event that triggered the pipeline run, e.g. push, pull_request
-      name: event-type
-      type: string
     - default: []
       description: Array of --build-arg values ("arg=value" strings) for buildah
       name: build-args
@@ -71,6 +67,22 @@ spec:
       description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
       name: build-args-file
       type: string
+    - default: ""
+      description: The name of the OpenShift Deployment we want to update
+      name: deployment-name
+      type: string
+    - default: ""
+      description: The Namespace of the Deployment we want to update
+      name: deployment-namespace
+      type: string
+    - default: "app-inference"
+      description: The Container of the Deployment that it's image will be updated
+      name: container-name
+      type: string
+    - name: image
+      type: string
+      description: Reference of the newly built image to use.
+      default: ""
   results:
     - name: IMAGE_URL
       value: $(tasks.build-container.results.IMAGE_URL)
@@ -138,8 +150,14 @@ spec:
       workspaces:
         - name: source
           workspace: workspace
-    - name: update-deployment
+    - name: update-deployment-patch
       params:
+        - name: deployment-name
+          value: $(params.deployment-name)
+        - name: deployment-namespace
+          value: $(params.deployment-namespace)
+        - name: container-name
+          value: $(params.container-name)
         - name: gitops-repo-url
           value: $(params.git-url)-gitops
         - name: image
@@ -150,14 +168,10 @@ spec:
         - build-container
       taskRef:
         kind: Task
-        name: update-deployment
-      when:
-        - input: $(params.event-type)
-          operator: notin
-          values:
-            - pull_request
-            - Merge Request
+        name: update-deployment-patch
   workspaces:
     - name: workspace
     - name: git-auth
+      optional: true
+    - name: gitops-auth
       optional: true

--- a/pac/source-repo/docker-pull-request.yaml
+++ b/pac/source-repo/docker-pull-request.yaml
@@ -6,13 +6,12 @@ metadata:
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{ values.defaultBranch }}]"
     pipelinesascode.tekton.dev/max-keep-runs: "2"
-    pipelinesascode.tekton.dev/pipeline: "{{values.rawUrl}}/pac/pipelines/docker-build-ai-rhdh.yaml"
+    pipelinesascode.tekton.dev/pipeline: "{{values.rawUrl}}/pac/pipelines/docker-build-ai-rhdh-pull-request.yaml"
     pipelinesascode.tekton.dev/task-0: "{{values.rawUrl}}/pac/tasks/init.yaml"
     pipelinesascode.tekton.dev/task-1: "{{values.rawUrl}}/pac/tasks/git-clone.yaml"
     pipelinesascode.tekton.dev/task-2: "{{values.rawUrl}}/pac/tasks/buildah-ai-rhdh.yaml"
-    pipelinesascode.tekton.dev/task-3: "{{values.rawUrl}}/pac/tasks/update-deployment.yaml"
-    pipelinesascode.tekton.dev/task-4: "{{values.rawUrl}}/pac/tasks/show-sbom-rhdh.yaml"
-    pipelinesascode.tekton.dev/task-5: "{{values.rawUrl}}/pac/tasks/summary.yaml"
+    pipelinesascode.tekton.dev/task-3: "{{values.rawUrl}}/pac/tasks/show-sbom-rhdh.yaml"
+    pipelinesascode.tekton.dev/task-4: "{{values.rawUrl}}/pac/tasks/summary.yaml"
 spec:
   params:
     - name: dockerfile
@@ -27,12 +26,8 @@ spec:
       value: {{ values.buildContext }}
     - name: revision
       value: '{{revision}}'
-    - name: event-type
-      value: '{{event_type}}'
-    - name: gitops-auth-secret-name
-      value: {{ values.gitopsSecretName }}
   pipelineRef:
-    name: docker-build-ai-rhdh
+    name: docker-build-ai-rhdh-pull-request
   workspaces:
     - name: git-auth
       secret:

--- a/pac/source-repo/docker-push.yaml
+++ b/pac/source-repo/docker-push.yaml
@@ -6,11 +6,11 @@ metadata:
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{ values.defaultBranch }}]"
     pipelinesascode.tekton.dev/max-keep-runs: "2"
-    pipelinesascode.tekton.dev/pipeline: "{{values.rawUrl}}/pac/pipelines/docker-build-ai-rhdh.yaml"
+    pipelinesascode.tekton.dev/pipeline: "{{values.rawUrl}}/pac/pipelines/docker-build-ai-rhdh-push-gitops.yaml"
     pipelinesascode.tekton.dev/task-0: "{{values.rawUrl}}/pac/tasks/init.yaml"
     pipelinesascode.tekton.dev/task-1: "{{values.rawUrl}}/pac/tasks/git-clone.yaml"
     pipelinesascode.tekton.dev/task-2: "{{values.rawUrl}}/pac/tasks/buildah-ai-rhdh.yaml"
-    pipelinesascode.tekton.dev/task-3: "{{values.rawUrl}}/pac/tasks/update-deployment.yaml"
+    pipelinesascode.tekton.dev/task-3: "{{values.rawUrl}}/pac/tasks/update-deployment-gitops.yaml"
     pipelinesascode.tekton.dev/task-4: "{{values.rawUrl}}/pac/tasks/show-sbom-rhdh.yaml"
     pipelinesascode.tekton.dev/task-5: "{{values.rawUrl}}/pac/tasks/summary.yaml"
 spec:
@@ -27,16 +27,18 @@ spec:
       value: {{ values.buildContext }}
     - name: revision
       value: '{{revision}}'
-    - name: event-type
-      value: '{{event_type}}'
     - name: gitops-auth-secret-name
       value: {{ values.gitopsSecretName }}
   pipelineRef:
-    name: docker-build-ai-rhdh
+    name: docker-build-ai-rhdh-push-gitops
+
   workspaces:
     - name: git-auth
       secret:
         secretName: "{{ git_auth_secret }}"
+    - name: gitops-auth
+      secret:
+        secretName: $(params.gitops-auth-secret-name)
     - name: workspace
       volumeClaimTemplate:
         spec:

--- a/pac/tasks/update-deployment-gitops.yaml
+++ b/pac/tasks/update-deployment-gitops.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: update-deployment
+  name: update-deployment-gitops
 spec:
   description: Task to update deployment with newly built image in gitops repository.
   params:
@@ -16,17 +16,15 @@ spec:
       default: gitops-auth-secret
       description: |
         Secret of basic-auth type containing credentials to commit into gitops repository.
-  volumes:
-    - name: gitops-auth-secret
+  workspaces:
+    - name: gitops-auth
+      mountPath: /gitops-auth-secret
+      optional: true
       secret:
         secretName: $(params.gitops-auth-secret-name)
-        optional: true
   steps:
     - name: patch-gitops
       image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
-      volumeMounts:
-        - name: gitops-auth-secret
-          mountPath: /gitops-auth-secret
       env:
         - name: PARAM_GITOPS_REPO_URL
           value: $(params.gitops-repo-url)

--- a/pac/tasks/update-deployment-patch.yaml
+++ b/pac/tasks/update-deployment-patch.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: update-deployment-patch
+spec:
+  description: Task to update deployment with newly built application image.
+  params:
+    - name: deployment-name
+      type: string
+      description: The name of the deployment that will be updated.
+    - name: deployment-namespace
+      type: string
+      description: The namespace of the deployment that will be updated
+    - name: container-name
+      description: The name of the container that its image will be updated.
+    - name: image
+      type: string
+      description: Reference of the newly built image to use.
+  steps:
+    - name: patch-deployment
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+      env:
+        - name: DEPLOYMENT_NAME
+          value: $(params.deployment-name)
+        - name: DEPLOYMENT_NAMESPACE
+          value: $(params.deployment-namespace)
+        - name: CONTAINER_NAME
+          value: $(params.container-name)
+        - name: NEW_IMAGE
+          value: $(params.image)
+      script: |
+        kubectl patch deployment ${DEPLOYMENT_NAME} --namespace ${DEPLOYMENT_NAMESPACE} --type 'merge' --patch "$( cat <<EOF
+        spec:
+          template:
+            spec:
+              containers:
+              - name: $CONTAINER_NAME
+                image: $NEW_IMAGE
+                envFrom:
+                - configMapRef:
+                    name: $DEPLOYMENT_NAME-model-config
+        EOF
+        )"
+        echo "Successfully updated ${CONTAINER_NAME} container's image to ${NEW_IMAGE}"


### PR DESCRIPTION
With this change and an associated change in the rhdh-pipeline repos, we are:
- creating separate build pipelines for pull requests, push when we want to employ gitops for deployment update, and push when we want to directly path the deployment object to update
- rather than a vanilla update-deployment task, we have update-deployment-gitops and update-deployment-patch 
- to better define what is unique and what is common across various pipelines, we've removed the use of when clauses to dynamically pick tasks based on events types or wokspace bindings; the anticipation is ths will facilitate auto generation down the line
- we update the update-deployment-gitops task in rhdh-pipelines to switch from a k8s volume to a tekton workspace for the gitops secret (where that workspace will be an optional workspace)
 - where the binding of the workspace is done in the on-push pipelineruns by listing the optional gitops secret workspace in its workspaces list
- and we'll remove the separate build pipeline and update deployment task in ai-lab-helm-charts with https://github.com/redhat-ai-dev/ai-lab-helm-charts/pull/29

For local testing of this PR, I created https://github.com/gabemontero/ai-lab-template/tree/upd-deploy-optional-steps but with changes to reference the branch for this PR, and then updated my local clone on the ai-rhdh-installer repo so that https://github.com/redhat-ai-dev/ai-rhdh-installer/blob/main/catalogs.yaml#L3 points to my `upd-deploy-optional-steps` branch in `ai-lab-template`