### PR TITLE
Add bearer auth support to update-deployment-patch

### DIFF
--- a/pac/tasks/update-deployment-patch.yaml
+++ b/pac/tasks/update-deployment-patch.yaml
@@ -30,6 +30,33 @@ spec:
           value: $(params.image)
       script: |-
         #!/bin/bash
+        # check if the updated deployment is a bearer authentication case.
+        INCLUDE_MODEL_ENDPOINT_SECRET=$(kubectl get configmap ${DEPLOYMENT_NAME}-app-config -n ${DEPLOYMENT_NAMESPACE} -o jsonpath="{.data.INCLUDE_MODEL_ENDPOINT_SECRET}")
+        MODEL_ENDPOINT_SECRET_NAME=$(kubectl get configmap ${DEPLOYMENT_NAME}-app-config -n ${DEPLOYMENT_NAMESPACE} -o jsonpath="{.data.MODEL_ENDPOINT_SECRET_NAME}")
+        MODEL_ENDPOINT_SECRET_KEY=$(kubectl get configmap ${DEPLOYMENT_NAME}-app-config -n ${DEPLOYMENT_NAMESPACE} -o jsonpath="{.data.MODEL_ENDPOINT_SECRET_KEY}")
+
+        # add the bearer secret in case is needed
+        if [[ ${INCLUDE_MODEL_ENDPOINT_SECRET} == "true" && -n ${MODEL_ENDPOINT_SECRET_NAME}  && -n ${MODEL_ENDPOINT_SECRET_KEY} ]]; then
+        kubectl patch deployment ${DEPLOYMENT_NAME} --namespace ${DEPLOYMENT_NAMESPACE} --type 'merge' --patch "$( cat <<EOF
+        spec:
+          template:
+            spec:
+              containers:
+              - name: $CONTAINER_NAME
+                image: $NEW_IMAGE
+                envFrom:
+                - configMapRef:
+                    name: $DEPLOYMENT_NAME-model-config
+                env:
+                - name: MODEL_ENDPOINT_BEARER
+                  valueFrom:
+                    secretKeyRef:
+                      name: $MODEL_ENDPOINT_SECRET_NAME
+                      key: $MODEL_ENDPOINT_SECRET_KEY
+        EOF
+        )"
+        else
+        # default case
         kubectl patch deployment ${DEPLOYMENT_NAME} --namespace ${DEPLOYMENT_NAMESPACE} --type 'merge' --patch "$( cat <<EOF
         spec:
           template:
@@ -42,4 +69,6 @@ spec:
                     name: $DEPLOYMENT_NAME-model-config
         EOF
         )"
+        fi
+
         echo "Successfully updated ${CONTAINER_NAME} container's image to ${NEW_IMAGE}"

--- a/pac/tasks/update-deployment-patch.yaml
+++ b/pac/tasks/update-deployment-patch.yaml
@@ -31,6 +31,7 @@ spec:
       script: |-
         #!/bin/bash
         # check if the updated deployment is a bearer authentication case.
+        # in other words check if the three configMap variables have been set in ${DEPLOYMENT_NAME}-app-config during the helm chart installation
         INCLUDE_MODEL_ENDPOINT_SECRET=$(kubectl get configmap ${DEPLOYMENT_NAME}-app-config -n ${DEPLOYMENT_NAMESPACE} -o jsonpath="{.data.INCLUDE_MODEL_ENDPOINT_SECRET}")
         MODEL_ENDPOINT_SECRET_NAME=$(kubectl get configmap ${DEPLOYMENT_NAME}-app-config -n ${DEPLOYMENT_NAMESPACE} -o jsonpath="{.data.MODEL_ENDPOINT_SECRET_NAME}")
         MODEL_ENDPOINT_SECRET_KEY=$(kubectl get configmap ${DEPLOYMENT_NAME}-app-config -n ${DEPLOYMENT_NAMESPACE} -o jsonpath="{.data.MODEL_ENDPOINT_SECRET_KEY}")


### PR DESCRIPTION
Updates the patch deployment task to check if the application requires bearer auth support. If yes it provides also the env var secret value of the bearer so it can be used for the existing model.

Is related to https://github.com/redhat-ai-dev/ai-lab-helm-charts/pull/33