### PR TITLE
Add retries for pipeline failures

### DIFF
--- a/pac/pipelines/docker-build-ai-rhdh-pull-request.yaml
+++ b/pac/pipelines/docker-build-ai-rhdh-pull-request.yaml
@@ -60,10 +60,6 @@ spec:
       description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
       name: build-args-file
       type: string
-    - default: "3"
-      type: string
-      name: task-retries
-      description: The number of retries of every pipeline task
   results:
     - name: IMAGE_URL
       value: $(tasks.build-container.results.IMAGE_URL)
@@ -75,7 +71,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
   tasks:
     - name: init
-      retries: $(params.task-retries)
+      retries: 3
       params:
         - name: image-url
           value: $(params.output-image)
@@ -84,7 +80,7 @@ spec:
       taskRef:
         name: init
     - name: clone-repository
-      retries: $(params.task-retries)
+      retries: 3
       params:
         - name: url
           value: $(params.git-url)
@@ -105,7 +101,7 @@ spec:
         - name: basic-auth
           workspace: git-auth
     - name: build-container
-      retries: $(params.task-retries)
+      retries: 3
       params:
         - name: IMAGE
           value: $(params.output-image)

--- a/pac/pipelines/docker-build-ai-rhdh-pull-request.yaml
+++ b/pac/pipelines/docker-build-ai-rhdh-pull-request.yaml
@@ -60,6 +60,10 @@ spec:
       description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
       name: build-args-file
       type: string
+    - default: "3"
+      type: string
+      name: task-retries
+      description: The number of retries of every pipeline task
   results:
     - name: IMAGE_URL
       value: $(tasks.build-container.results.IMAGE_URL)
@@ -71,6 +75,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
   tasks:
     - name: init
+      retries: $(params.task-retries)
       params:
         - name: image-url
           value: $(params.output-image)
@@ -79,6 +84,7 @@ spec:
       taskRef:
         name: init
     - name: clone-repository
+      retries: $(params.task-retries)
       params:
         - name: url
           value: $(params.git-url)
@@ -99,6 +105,7 @@ spec:
         - name: basic-auth
           workspace: git-auth
     - name: build-container
+      retries: $(params.task-retries)
       params:
         - name: IMAGE
           value: $(params.output-image)

--- a/pac/pipelines/docker-build-ai-rhdh-push-gitops.yaml
+++ b/pac/pipelines/docker-build-ai-rhdh-push-gitops.yaml
@@ -64,10 +64,6 @@ spec:
       description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
       name: build-args-file
       type: string
-    - default: "3"
-      type: string
-      name: task-retries
-      description: The number of retries of every pipeline task
   results:
     - name: IMAGE_URL
       value: $(tasks.build-container.results.IMAGE_URL)
@@ -79,7 +75,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
   tasks:
     - name: init
-      retries: $(params.task-retries)
+      retries: 3
       params:
         - name: image-url
           value: $(params.output-image)
@@ -88,7 +84,7 @@ spec:
       taskRef:
         name: init
     - name: clone-repository
-      retries: $(params.task-retries)
+      retries: 3
       params:
         - name: url
           value: $(params.git-url)
@@ -109,7 +105,7 @@ spec:
         - name: basic-auth
           workspace: git-auth
     - name: build-container
-      retries: $(params.task-retries)
+      retries: 3
       params:
         - name: IMAGE
           value: $(params.output-image)
@@ -135,7 +131,7 @@ spec:
         - name: source
           workspace: workspace
     - name: update-deployment-gitops
-      retries: $(params.task-retries)
+      retries: 3
       params:
         - name: gitops-repo-url
           value: $(params.git-url)-gitops

--- a/pac/pipelines/docker-build-ai-rhdh-push-gitops.yaml
+++ b/pac/pipelines/docker-build-ai-rhdh-push-gitops.yaml
@@ -64,6 +64,10 @@ spec:
       description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
       name: build-args-file
       type: string
+    - default: "3"
+      type: string
+      name: task-retries
+      description: The number of retries of every pipeline task
   results:
     - name: IMAGE_URL
       value: $(tasks.build-container.results.IMAGE_URL)
@@ -75,6 +79,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
   tasks:
     - name: init
+      retries: $(params.task-retries)
       params:
         - name: image-url
           value: $(params.output-image)
@@ -83,6 +88,7 @@ spec:
       taskRef:
         name: init
     - name: clone-repository
+      retries: $(params.task-retries)
       params:
         - name: url
           value: $(params.git-url)
@@ -103,6 +109,7 @@ spec:
         - name: basic-auth
           workspace: git-auth
     - name: build-container
+      retries: $(params.task-retries)
       params:
         - name: IMAGE
           value: $(params.output-image)
@@ -128,6 +135,7 @@ spec:
         - name: source
           workspace: workspace
     - name: update-deployment-gitops
+      retries: $(params.task-retries)
       params:
         - name: gitops-repo-url
           value: $(params.git-url)-gitops

--- a/pac/pipelines/docker-build-ai-rhdh-push-patch.yaml
+++ b/pac/pipelines/docker-build-ai-rhdh-push-patch.yaml
@@ -72,10 +72,6 @@ spec:
       description: The Container of the Deployment that it's image will be updated
       name: container-name
       type: string
-    - default: "3"
-      type: string
-      name: task-retries
-      description: The number of retries of every pipeline task
   results:
     - name: IMAGE_URL
       value: $(tasks.build-container.results.IMAGE_URL)
@@ -87,7 +83,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
   tasks:
     - name: init
-      retries: $(params.task-retries)
+      retries: 3
       params:
         - name: image-url
           value: $(params.output-image)
@@ -96,7 +92,7 @@ spec:
       taskRef:
         name: init
     - name: clone-repository
-      retries: $(params.task-retries)
+      retries: 3
       params:
         - name: url
           value: $(params.git-url)
@@ -117,7 +113,7 @@ spec:
         - name: basic-auth
           workspace: git-auth
     - name: build-container
-      retries: $(params.task-retries)
+      retries: 3
       params:
         - name: IMAGE
           value: $(params.output-image)
@@ -143,7 +139,7 @@ spec:
         - name: source
           workspace: workspace
     - name: update-deployment-patch
-      retries: $(params.task-retries)
+      retries: 3
       params:
         - name: deployment-name
           value: $(params.deployment-name)

--- a/pac/pipelines/docker-build-ai-rhdh-push-patch.yaml
+++ b/pac/pipelines/docker-build-ai-rhdh-push-patch.yaml
@@ -72,6 +72,10 @@ spec:
       description: The Container of the Deployment that it's image will be updated
       name: container-name
       type: string
+    - default: "3"
+      type: string
+      name: task-retries
+      description: The number of retries of every pipeline task
   results:
     - name: IMAGE_URL
       value: $(tasks.build-container.results.IMAGE_URL)
@@ -83,6 +87,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
   tasks:
     - name: init
+      retries: $(params.task-retries)
       params:
         - name: image-url
           value: $(params.output-image)
@@ -91,6 +96,7 @@ spec:
       taskRef:
         name: init
     - name: clone-repository
+      retries: $(params.task-retries)
       params:
         - name: url
           value: $(params.git-url)
@@ -111,6 +117,7 @@ spec:
         - name: basic-auth
           workspace: git-auth
     - name: build-container
+      retries: $(params.task-retries)
       params:
         - name: IMAGE
           value: $(params.output-image)
@@ -136,6 +143,7 @@ spec:
         - name: source
           workspace: workspace
     - name: update-deployment-patch
+      retries: $(params.task-retries)
       params:
         - name: deployment-name
           value: $(params.deployment-name)


### PR DESCRIPTION
The PR adds a number of 3 retries in case a task fails in each one of the 3 pipelines available. This way we could improve a bit the user experience in case for example quay or github are experiencing issues.

I've used the suggested changes here:

![image](https://github.com/user-attachments/assets/15ec26d8-bc4d-42c2-9d5b-cce88d0e58bc)
